### PR TITLE
Revert "do not call signal-unsafe function inside sighanlder"

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -1541,8 +1541,6 @@ setup(void)
 	Atom utf8string;
 
 	/* clean up any zombies immediately */
-	if (signal(SIGCHLD, sigchld) == SIG_ERR)
-		die("can't install SIGCHLD handler:");
 	sigchld(0);
 
 	/* init screen */
@@ -1640,6 +1638,8 @@ showhide(Client *c)
 void
 sigchld(int unused)
 {
+	if (signal(SIGCHLD, sigchld) == SIG_ERR)
+		die("can't install SIGCHLD handler:");
 	while (0 < waitpid(-1, NULL, WNOHANG));
 }
 


### PR DESCRIPTION
This reverts commit 6613d9f9a1a5630bab30bc2b70bdc793977073ee.

Discussed on the mailinglist:
https://lists.suckless.org/hackers/2207/18405.html